### PR TITLE
Replace cba hashes

### DIFF
--- a/functions/api/fn_doLoadoutForUnit.sqf
+++ b/functions/api/fn_doLoadoutForUnit.sqf
@@ -14,7 +14,7 @@ private _loadoutHash = [_unit, _configPath] call FUNC(GetUnitLoadoutFromConfig);
 [_loadoutHash, _unit] call FUNC(randomizeLoadout);
 _loadoutHash = [_loadoutHash, _unit] call FUNC(ApplyRevivers);
 
-if (([_loadoutHash] call CBA_fnc_hashSize) > 0) then {
+if ((count _loadoutHash) > 0) then {
     [_loadoutHash, _unit] call FUNC(DoLoadout);
 } else {
     TRACE_1("no loadout entries found for %1, skipping unit", _unit);

--- a/functions/api/fn_verifyLoadouts.sqf
+++ b/functions/api/fn_verifyLoadouts.sqf
@@ -95,8 +95,8 @@ private _fnc_checkContainers = {
     params ["_loadoutHash","_unit"];
     {
         _x params ["_containerKey","_itemsKey"];
-        _container = [_loadoutHash,_containerKey] call CBA_fnc_hashGet;
-        _itemsList = [_loadoutHash,_itemsKey] call CBA_fnc_hashGet;
+        _container = _loadoutHash get _containerKey;
+        _itemsList = _loadoutHash get _itemsKey;
 
         if (!isNil "_itemsList" && (isNil "_container" || {_container == ""}) && {count _itemsList > 0}) then {
             _errorLog pushBack [format ["no %1 for %2",_containerKey,_itemsKey],_unit];
@@ -135,13 +135,13 @@ private _fnc_checkWeapons = {
 
     {
         _x params ["_weaponKey","_weaponAccessoryKeys","_magazineKeys"];
-        _weaponClassname = [_loadoutHash,_weaponKey] call CBA_fnc_hashGet;
+        _weaponClassname = _loadoutHash get _weaponKey;
         if (!isNil "_weaponClassname" && {_weaponClassname != ""}) then {
             if !([_weaponClassname,["cfgWeapons"]] call _fnc_checkClassExists) then {
                 _errorLog pushBack [format ["%1 %2 does not exist",_x,_weaponClassname]];
             } else {
                 {
-                    _accessoryClassname = [_loadoutHash,_x] call CBA_fnc_hashGet;
+                    _accessoryClassname = _loadoutHash get _x;
                     if (!isNil "_accessoryClassname" && {_accessoryClassname != ""}) then {
                         if !([_weaponClassname,_accessoryClassname,_forEachIndex] call _fnc_checkAccessoryFits) then {
                             _errorLog pushBack [format ["%1 %2 is not compatible with weapon %3",_x,_accessoryClassname,_weaponClassname],_unit];
@@ -150,7 +150,7 @@ private _fnc_checkWeapons = {
                 } forEach _weaponAccessoryKeys;
 
                 {
-                    _magazineClassname = [_loadoutHash,_x] call CBA_fnc_hashGet;
+                    _magazineClassname = _loadoutHash get _x;
                     if (!isNil "_magazineClassname" && {_magazineClassname != ""}) then {
                         if !([_weaponClassname,_magazineClassname,_forEachIndex] call _fnc_magazineFits) then {
                             _errorLog pushBack [format ["%1 %2 is not compatible with weapon %3",_x,_magazineClassname,_weaponClassname],_unit];
@@ -262,7 +262,7 @@ private _fnc_checkOther = {
     params ["_loadoutHash","_unit"];
 
     {
-        _otherClassname = [_loadoutHash,_x] call CBA_fnc_hashGet;
+        _otherClassname = _loadoutHash get _x;
         if (!isNil "_otherClassname" && {_otherClassname != ""}) then {
             if !([_otherClassname] call _fnc_checkClassExists) then {
                 _errorLog pushBack [format ["%1 %2 does not exist",_x,_otherClassname],_unit];
@@ -316,7 +316,7 @@ private _verifiedLoadoutCount = 0;
     [_loadoutHash] call FUNC(randomizeLoadout);
     _loadoutHash = [_loadoutHash,_x] call FUNC(ApplyRevivers);
 
-    if (([_loadoutHash] call CBA_fnc_hashSize) > 0) then {
+    if ((count _loadoutHash) > 0) then {
         [_loadoutHash,_x] call _fnc_verify;
         _verifiedLoadoutCount = _verifiedLoadoutCount + 1;
     };

--- a/functions/customgear/fn_createCustomGearDialog.sqf
+++ b/functions/customgear/fn_createCustomGearDialog.sqf
@@ -58,12 +58,12 @@ private _ctrlFirstActivated = controlNull;
     _ctrlButton setVariable [QGVAR(hashKey), _hashKey];
     _ctrlButton ctrlAddEventHandler ["buttonClick", {[_this#0, true] call FUNC(onCustomGearTabButton)}];
 
-    private _availableOptions = [_loadoutOptionsHash, _hashKey] call CBA_fnc_hashGet;
+    private _availableOptions = _loadoutOptionsHash getOrDefault [_hashKey, []];
 
     // check if weapon categories have accessories available
     private _hasSubOptionsAvailable = false;
     {
-        private _availableSubOptions = [_loadoutOptionsHash, _x] call CBA_fnc_hashGet;
+        private _availableSubOptions = _loadoutOptionsHash getOrDefault [_x, []];
         if (_availableSubOptions isEqualType [] && {count _availableSubOptions > 0}) exitWith {
             _hasSubOptionsAvailable = true;
         };

--- a/functions/customgear/fn_getCustomGearOptions.sqf
+++ b/functions/customgear/fn_getCustomGearOptions.sqf
@@ -2,13 +2,13 @@
 
 params [["_unit", objNull], ["_loadoutHash", []], ["_ignoreCurrentLoadout", false]];
 
-private _loadoutOptionsHash = [[], false] call CBA_fnc_hashCreate;
+private _loadoutOptionsHash = createHashMap;
 private _currentLoadout = getUnitLoadout _unit;
 private _allowedCategories = _unit getVariable [QGVAR(customGearAllowedCategories), GVAR(customGearAllowedCategories)];
 
 {
     private _key = _x;
-    private _value = [_loadoutHash, _key] call CBA_fnc_hashGet;
+    private _value = _loadoutHash get _key;
     if (!isNil "_value" && {_value isEqualType []}) then {_value = _value apply {toLower _x}};
 
     if (
@@ -21,7 +21,7 @@ private _allowedCategories = _unit getVariable [QGVAR(customGearAllowedCategorie
             ((toLower ([_unit, _key, true] call FUNC(getCurrentItem))) in _value)
         }
     ) then {
-        [_loadoutOptionsHash, _key, _value] call CBA_fnc_hashSet;
+        _loadoutOptionsHash set [_key, _value];
     };
 } forEach ([CUSTOMGEAR_SUPPORTED_KEYS] arrayIntersect _allowedCategories);
 

--- a/functions/customgear/fn_initCustomGear.sqf
+++ b/functions/customgear/fn_initCustomGear.sqf
@@ -43,7 +43,7 @@ GVAR(customGearCondition) = if (_enabled isEqualType 0) then {
     _unit setVariable [QGVAR(customGearOptionsCache), _customGearOptionsHash];
 
     // notification the first time customization becomes available after loadout application
-    if (count ([_customGearOptionsHash] call CBA_fnc_hashKeys) > 0) then {
+    if (count _customGearOptionsHash > 0) then {
         [{(missionNamespace getVariable ["CBA_missionTime", 0]) > 10 && {[_this] call GVAR(customGearCondition)}}, {
             if (isClass (configfile >> "CfgNotifications" >> "GRAD_saveMarkers_notification")) then {
                 ["GRAD_saveMarkers_notification", ["GRAD CUSTOM GEAR", "Loadout customization now available. (Selfinteract >> Equipment)"]] call BIS_fnc_showNotification;
@@ -76,7 +76,7 @@ private _action = [
                 private _loadoutHash = [_unit, _configPath] call FUNC(GetUnitLoadoutFromConfig);
                 private _customGearOptionsHash = [_unit, _loadoutHash] call FUNC(getCustomGearOptions);
             };
-            count ([_customGearOptionsHash] call CBA_fnc_hashKeys) > 0
+            count _customGearOptionsHash > 0
         }
     }
 ] call ace_interact_menu_fnc_createAction;

--- a/functions/customgear/fn_onCustomGearTabButton.sqf
+++ b/functions/customgear/fn_onCustomGearTabButton.sqf
@@ -15,12 +15,12 @@ _ctrlTabSelected ctrlCommit 0;
 
 // get available options for selected category
 private _hashKey = _button getVariable [QGVAR(hashKey), ""];
-private _loadoutOptionsHash = _display getVariable [QGVAR(loadoutOptionsHash), []];
-private _availableOptions = if !([_loadoutOptionsHash] call CBA_fnc_isHash) then {
+private _loadoutOptionsHash = _display getVariable [QGVAR(loadoutOptionsHash), false];
+private _availableOptions = if (_loadoutOptionsHash isEqualTo false) then {
     ERROR("_loadoutOptionsHash got lost along the way and is no longer a hash.");
     []
 } else {
-    [_loadoutOptionsHash, _hashKey] call CBA_fnc_hashGet
+    _loadoutOptionsHash getOrDefault [_hashKey, false];
 };
 
 // fill listbox with available options
@@ -95,7 +95,7 @@ if (_isLeftSide) then {
 
             _hashKey = _hashKeyArray select _forEachIndex;
             _ctrlButton setVariable [QGVAR(hashKey), _hashKey];
-            _availableOptions = [_loadoutOptionsHash, _hashKey] call CBA_fnc_hashGet;
+            _availableOptions = _loadoutOptionsHash get _hashKey;
 
             if !(_availableOptions isEqualType [] && {count _availableOptions > 0}) then {
                 _ctrlButton ctrlEnable false;

--- a/functions/customgear/fn_onCustomGearUnload.sqf
+++ b/functions/customgear/fn_onCustomGearUnload.sqf
@@ -11,13 +11,13 @@ GVAR(customGearCam) = nil;
 private _unit = _display getVariable [QGVAR(unit), objNull];
 private _loadoutOptionsHash = _display getVariable [QGVAR(loadoutOptionsHash), []];
 
-private _savedCustomGearHash = [[], false] call CBA_fnc_hashCreate;
+private _savedCustomGearHash = createHashMap;
 
-[_loadoutOptionsHash, {
-    private _currentItem = [_unit, _key, true] call FUNC(getCurrentItem);
+{
+    private _currentItem = [_unit, _x, true] call FUNC(getCurrentItem);
     if (_currentItem isEqualType "" && {_currentItem != ""}) then {
-        [_savedCustomGearHash, _key, toLower _currentItem] call CBA_fnc_hashSet;
+        _savedCustomGearHash set [_x, toLower _currentItem];
     };
-}] call CBA_fnc_hashEachPair;
+} forEach _loadoutOptionsHash;
 
 _unit setVariable [QGVAR(savedCustomGearHash), _savedCustomGearHash, false];

--- a/functions/extract/fn_extractLoadoutFromConfig.sqf
+++ b/functions/extract/fn_extractLoadoutFromConfig.sqf
@@ -30,16 +30,16 @@ private _isWeapon = {
     "handgunWeaponAttachments"
 ];
 
-private _configValues = [] call CBA_fnc_hashCreate;
+private _configValues = createHashMap;
 
 {
     private _value = [_configPath >> _x, "text", false] call  CBA_fnc_getConfigEntry;
     if (!(_value isEqualTo false)) then {
-        [_configValues, _x, _value] call CBA_fnc_hashSet;
+        _configValues set [_x, _value];
     };
     _value = [_configPath >> _x, "array", false] call CBA_fnc_getConfigEntry;
     if (!(_value isEqualTo false)) then {
-        [_configValues, _x, _value] call CBA_fnc_hashSet;
+        _configValues set [_x, _value];
     };
 } forEach [
     "uniform",
@@ -80,7 +80,7 @@ private _configValues = [] call CBA_fnc_hashCreate;
 {
     private _value = [_configPath >> _x, "array", false] call  CBA_fnc_getConfigEntry;
     if (!(_value isEqualTo false)) then {
-        [_configValues, _x, _value] call CBA_fnc_hashSet;
+        _configValues set [_x, _value];
     };
 } forEach [
     "addItemsToUniform",
@@ -137,7 +137,7 @@ if (!(_value isEqualTo false)) then {
         };
 
     } forEach _value;
-    [_configValues, "addItemsToBackpack", _value] call CBA_fnc_hashSet;
+    _configValues set ["addItemsToBackpack", _value];
 };
 
 _configValues

--- a/functions/general/fn_defactionizeType.sqf
+++ b/functions/general/fn_defactionizeType.sqf
@@ -9,8 +9,8 @@ private _defactionedClassname = "";
 } forEach [FUNC(VanillaMilitaryDefactionizer), FUNC(VanillaCivDefactionizer)];
 
 if (_defactionedClassname == "") then {
-    WARNING_1("type name of unit %1 cannot be defactionized :( defaulting to classname", _unit);
     _defactionedClassname = typeOf _unit;
+    WARNING_2("type name of unit %1 cannot be defactionized :( defaulting to classname %2", _unit, _defactionedClassname);    
 };
 
 TRACE_2("unit class %1 defactionized to %2", typeOf _unit, _defactionedClassname);

--- a/functions/general/fn_doLoadout.sqf
+++ b/functions/general/fn_doLoadout.sqf
@@ -1,10 +1,9 @@
 #include "component.hpp"
 
-params ["_loadoutHash", "_loadoutTarget"];
-
-if (typeName _loadoutHash != "ARRAY") then {
-    throw "loadoutHash is not of type array (and thus, no cba hash) :(("
-};
+params [
+    ["_loadoutHash", createHashMap, [createHashMap]],
+    ["_loadoutTarget", objNull, [objNull]]
+];
 
 private _unitLoadout = [
   [], [], [], // weapons

--- a/functions/general/fn_hashToUnitLoadout.sqf
+++ b/functions/general/fn_hashToUnitLoadout.sqf
@@ -1,13 +1,9 @@
 #include "component.hpp"
 
-params ["_loadoutHash", "_unitLoadout"];
-
-if (typeName _loadoutHash != "ARRAY") then {
-    throw "loadoutHash is not of type array (and thus, no cba hash) :(("
-};
-if (typeName _unitLoadout != "ARRAY") then {
-    throw "_unitLoadout is not of type array :(("
-};
+params [
+    ["_loadoutHash", createHashMap, [createHashMap]],
+    ["_unitLoadout", [], [[]]]
+];
 
 // CBA_fnc_findTypeName ? CBA_fnc_findTypeOf ?
 
@@ -39,8 +35,8 @@ private _walkIntoArray = {
 private _assignFromLoadoutHash = {
     params [["_indices",[]],["_entryName",""],"_classNameToPickOrMapper"];
 
-    if ( [_loadoutHash, _entryName] call CBA_fnc_hashHasKey ) then {
-        private _value = [_loadoutHash, _entryName] call CBA_fnc_hashGet;
+    if ( _entryName in _loadoutHash ) then {
+        private _value = _loadoutHash get _entryName;
         if (!(isNil "_classNameToPickOrMapper")) then {
             if (typeName _classNameToPickOrMapper == "CONFIG") then {
                 _value = [_value, _classNameToPickOrMapper] call _getFirstOfType;

--- a/functions/general/fn_mergeLoadoutHierarchy.sqf
+++ b/functions/general/fn_mergeLoadoutHierarchy.sqf
@@ -2,15 +2,15 @@
 
 params ["_loadoutHierarchy"];
 
-private _mergedLoadout = [] call CBA_fnc_hashCreate;
+private _mergedLoadout = createHashMap;
 
 {
     private _currentLevel = _x;
 
     {
-        if ([_currentLevel, _x] call CBA_fnc_hashHasKey) then {
-            _newValue = [_currentLevel, _x] call CBA_fnc_hashGet;
-            [_mergedLoadout, _x, _newValue] call CBA_fnc_hashSet;
+        if (_x in _currentLevel) then {
+            _newValue = _currentLevel get _x;
+            _mergedLoadout set [_x, _newValue];
         };
     } forEach [
         "uniform",
@@ -50,13 +50,13 @@ private _mergedLoadout = [] call CBA_fnc_hashCreate;
 
     // add* values must be appended
     {
-        if ([_currentLevel, _x] call CBA_fnc_hashHasKey) then {
-            _oldValue = [_mergedLoadout, _x] call CBA_fnc_hashGet;
+        if (_x in _currentLevel) then {
+            _oldValue = _mergedLoadout get _x;
             if (isNil "_oldValue") then {
                 _oldValue = [];
             };
-            _addValue = [_currentLevel, _x] call CBA_fnc_hashGet;
-            [_mergedLoadout, _x, _oldValue + _addValue] call CBA_fnc_hashSet;
+            _addValue = _currentLevel get _x;
+            _mergedLoadout set [_x, _oldValue + _addValue];
         };
     } forEach [
         "addItemsToUniform",

--- a/functions/general/fn_normalizeContent.sqf
+++ b/functions/general/fn_normalizeContent.sqf
@@ -6,17 +6,17 @@
 
 params ["_contentFromConfig"];
 
-private _CBA_fnc_hashIncr = {
+private _hashIncr = {
     params ["_hash","_key"];
 
-    _value = 1;
-    if ([_hash, _key] call CBA_fnc_hashHasKey) then {
-        _value = _value + ([_hash, _key] call CBA_fnc_hashGet);
+    private _value = 1;
+    if (_key in _hash) then {
+        _value = _value + (_hash get _key);
     };
-    [_hash, _key, _value] call CBA_fnc_hashSet;
+    _hash set [_key, _value];
 };
 
-private _magazines = [] call CBA_fnc_hashCreate;
+private _magazines = createHashMap;
 private _contentForLoadout = [];
 
 {
@@ -30,24 +30,21 @@ private _contentForLoadout = [];
             if (!(_underbarrelMagazine isEqualTo "") && isNumber (configFile >> "CfgMagazines" >> _underbarrelMagazine >> "count")) then {
                 _underbarrelMagazine = [_underbarrelMagazine, (getNumber (configFile >> "CfgMagazines" >> _underbarrelMagazine >> "count"))];
             };
-            _contentForLoadout pushBack [[_weapon, _muzzle, _pointer, _optics, _magazine, _underbarrelMagazine, _underbarrel],1];
+            _contentForLoadout pushBack [[_weapon, _muzzle, _pointer, _optics, _magazine, _underbarrelMagazine, _underbarrel], 1];
         };
     } else {
-        [_magazines, _x] call _CBA_fnc_hashIncr;
+        [_magazines, _x] call _hashIncr;
     };
 } forEach _contentFromConfig;
 
-[
-    _magazines,
-    {
-        _className = _key;
+{
+    _className = _x;
 
-        if (_className isKindOf ["CA_Magazine", configFile >> "CfgMagazines"]) then {
-            _contentForLoadout pushBack [_key, _value, 1];
-        } else {
-            _contentForLoadout pushBack [_key, _value];
-        };
-    }
-] call CBA_fnc_hashEachPair;
+    if (_className isKindOf ["CA_Magazine", configFile >> "CfgMagazines"]) then {
+        _contentForLoadout pushBack [_x, _y, 1];
+    } else {
+        _contentForLoadout pushBack [_x, _y];
+    };
+} forEach _magazines;
 
 _contentForLoadout

--- a/functions/general/fn_randomizeLoadout.sqf
+++ b/functions/general/fn_randomizeLoadout.sqf
@@ -22,16 +22,16 @@ private _randomizationEnabledForUnit = switch (true) do {
 };
 
 {
-    private _value = [_loadoutHash, _x] call CBA_fnc_hashGet;
+    private _value = _loadoutHash get _x;
     if (!isNil "_value" && {_value isEqualType []}) then {
         if (count _value == 0) then {_value = ""} else {
             _value = _value apply {toLower _x};
             if (
                 !isNil "_savedCustomGearHash" &&
-                {[_savedCustomGearHash, _x] call CBA_fnc_hashHasKey} &&
-                {([_savedCustomGearHash, _x] call CBA_fnc_hashGet) in _value}
+                {_x in _savedCustomGearHash} &&
+                {(_savedCustomGearHash get _x) in _value}
             ) then {
-                _value = [_savedCustomGearHash, _x] call CBA_fnc_hashGet;
+                _value = _savedCustomGearHash get _x;
             } else {
                 if (_randomizationEnabledForUnit) then {
                     _value = selectRandom _value;
@@ -40,7 +40,7 @@ private _randomizationEnabledForUnit = switch (true) do {
                 };
             };
         };
-        [_loadoutHash, _x, _value] call CBA_fnc_hashSet;
+        _loadoutHash set [_x, _value];
     };
 } forEach [
     "uniform",

--- a/functions/revivers/fn_applyRevivers.sqf
+++ b/functions/revivers/fn_applyRevivers.sqf
@@ -2,19 +2,16 @@
 
 params [["_loadoutHash", []], ["_unit", objNull]];
 
-[
-    _loadoutHash,
+{
+    _oldValue = _y;
+    _revivers = [_x] call FUNC(GetRevivers);
     {
-        _oldValue = _value;
-        _revivers = [_key] call FUNC(GetRevivers);
-        {
-            _value = [_value, _unit] call _x;
-        } forEach _revivers;
+        _y = [_y, _unit] call _x;
+    } forEach _revivers;
 
-        TRACE_2("revivers: replaced %1 with %2", _oldValue, _value);
+    TRACE_2("revivers: replaced %1 with %2", _oldValue, _y);
 
-        [_loadoutHash, _key, _value] call CBA_fnc_hashSet;
-    }
-] call CBA_fnc_hashEachPair;
+    _loadoutHash set [_x, _y];
+} forEach _loadoutHash;
 
 _loadoutHash


### PR DESCRIPTION
Replace CBA hashes with native HashMap instances.

I started the CO_Template and loadouts worked, so… at least basic functionality isnt broken. 

The only critical parts actually are those hashes where there was a default value (that now are defined when *get*ting instead of when *defining the hash*), all other replacements are direct equivalents so should be fine.