### PR TITLE
Correct classes in docs

### DIFF
--- a/docs/creatingLoadouts.md
+++ b/docs/creatingLoadouts.md
@@ -77,7 +77,7 @@ There are a couple of generic classes for you to use, ontop of being able to spe
     * Side/
         * Blufor|Opfor|Independent|Civilian
         * BluforAi|OpforAi|IndependentAi|CivilianAi
-        * BluforPlayer|OpforPlayer|IndependentPlayer|CivilianPlayer
+        * BluforPlayers|OpforPlayers|IndependentPlayers|CivilianPlayers
     * Type/
         * class name, e.g. B_Soldier_F
     * Rank/


### PR DESCRIPTION
This will correct the docs to match 
https://github.com/gruppe-adler/grad-loadout/blob/6a8d48ee8c1b5319faf5afba7947d82cc9579856/functions/general/fn_getUnitLoadoutFromConfig.sqf#L35
found by Searinox